### PR TITLE
Add score manager and game over panel

### DIFF
--- a/Assets/Scripts/Pipe.cs
+++ b/Assets/Scripts/Pipe.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+/// <summary>
+/// Detects when the player has passed this pipe and awards score.
+/// Attach this to the pipe prefab root object.
+/// </summary>
+public class Pipe : MonoBehaviour
+{
+    private bool scored;
+    private Transform player;
+
+    private void Start()
+    {
+        GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
+        if (playerObj != null)
+            player = playerObj.transform;
+    }
+
+    private void Update()
+    {
+        if (!scored && player != null && player.position.x > transform.position.x)
+        {
+            scored = true;
+            if (ScoreManager.Instance != null)
+                ScoreManager.Instance.AddScore(1);
+        }
+    }
+}

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -94,6 +94,8 @@ public class PlayerController : MonoBehaviour
         if (operatorComponent != null)
         {
             ApplyOperator(operatorComponent);
+            if (ScoreManager.Instance != null)
+                ScoreManager.Instance.AddScore(1);
             Destroy(collision.gameObject);
         }
     }
@@ -143,6 +145,7 @@ public class PlayerController : MonoBehaviour
         isGameOver = true;
         rb.velocity = Vector2.zero;
         rb.isKinematic = true;
-        // Additional game over logic (UI, restart, etc.) can be added here
+        if (ScoreManager.Instance != null)
+            ScoreManager.Instance.ShowGameOver();
     }
 }

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Tracks the player's score and high score using PlayerPrefs and updates the UI.
+/// Also exposes a restart method for the Game Over UI button.
+/// </summary>
+public class ScoreManager : MonoBehaviour
+{
+    public static ScoreManager Instance { get; private set; }
+
+    [Header("UI References")]
+    [Tooltip("Text displaying the current score during play")]
+    public Text scoreText;
+    [Tooltip("Game over panel shown when the player loses")] public GameObject gameOverPanel;
+    [Tooltip("Text displaying the final score in the game over panel")]
+    public Text gameOverScoreText;
+    [Tooltip("Text displaying the high score in the game over panel")]
+    public Text gameOverHighScoreText;
+
+    private int score;
+    private int highScore;
+
+    private const string HighScoreKey = "HighScore";
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        highScore = PlayerPrefs.GetInt(HighScoreKey, 0);
+        UpdateScoreUI();
+        if (gameOverPanel != null)
+            gameOverPanel.SetActive(false);
+    }
+
+    /// <summary>
+    /// Adds to the current score and updates the persistent high score if needed.
+    /// </summary>
+    public void AddScore(int amount)
+    {
+        score += amount;
+        if (score > highScore)
+        {
+            highScore = score;
+            PlayerPrefs.SetInt(HighScoreKey, highScore);
+        }
+        UpdateScoreUI();
+    }
+
+    private void UpdateScoreUI()
+    {
+        if (scoreText != null)
+            scoreText.text = score.ToString();
+        if (gameOverScoreText != null)
+            gameOverScoreText.text = $"Score: {score}";
+        if (gameOverHighScoreText != null)
+            gameOverHighScoreText.text = $"Best: {highScore}";
+    }
+
+    /// <summary>
+    /// Displays the game over panel.
+    /// </summary>
+    public void ShowGameOver()
+    {
+        UpdateScoreUI();
+        if (gameOverPanel != null)
+            gameOverPanel.SetActive(true);
+    }
+
+    /// <summary>
+    /// Resets the score and hides the game over panel.
+    /// Call this when restarting the scene.
+    /// </summary>
+    public void ResetScore()
+    {
+        score = 0;
+        UpdateScoreUI();
+        if (gameOverPanel != null)
+            gameOverPanel.SetActive(false);
+    }
+
+    /// <summary>
+    /// Reloads the current scene. Hook this to the restart button.
+    /// </summary>
+    public void Restart()
+    {
+        ResetScore();
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A Flappy Bird style math game.
 - `Operator.cs` is added to operator objects (`+1`, `-2`, `*3`, etc.) to define the mathematical operation applied when the player collides with them.
 - `Spawner.cs` periodically spawns pipe obstacles with a configurable gap and can
   randomly place operator-number prefabs inside that gap.
+- `ScoreManager.cs` keeps track of the player's score and high score, displaying
+  them on the UI and exposing a restart method for the game over menu.
+- `Pipe.cs` awards a point when the player successfully passes a pipe.
 
 ### Attaching scripts
 1. Import the **Input System** package and create an Input Actions asset with a `Flap` action bound to the space bar and primary press (mouse or touch).


### PR DESCRIPTION
## Summary
- add `ScoreManager` to track score and high score
- reward points when an operator is collected or a pipe is passed
- show a game over UI panel with restart support
- document new scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884fd656df483308ba40da44876196c